### PR TITLE
fix(element-focus): restore old blur and focus behaviour in jsdom

### DIFF
--- a/projects/spectator/src/lib/internals/element-focus.ts
+++ b/projects/spectator/src/lib/internals/element-focus.ts
@@ -29,5 +29,8 @@ export function patchElementFocus(element: HTMLElement): void {
     }
     element.blur = () => dispatchFakeEvent(element, 'blur');
     element[IS_FOCUS_PATCHED_PROP] = true;
+  } else {
+    element.focus = () => dispatchFakeEvent(element, 'focus');
+    element.blur = () => dispatchFakeEvent(element, 'blur');
   }
 }


### PR DESCRIPTION
Fixes: #482

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/spectator/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

8.0.4 broke element blur behaviour in jsdom.

Issue Number: N/A


## What is the new behavior?

Restored old element blur behaviour in jsdom

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
